### PR TITLE
Removing Doc Badge as it points to ReadTheDocs for a different project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ It provides:
 [![Python Version](https://img.shields.io/badge/python-3.9-brightgreen.svg)]()
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 ![ActionBuild](https://github.com/awslabs/aws-customer-churn-pipeline/actions/workflows/testing.yaml/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/ansicolortags/badge/?version=latest)](http://ansicolortags.readthedocs.io/?badge=latest)
 ![Release Version](https://img.shields.io/github/v/release/awslabs/aws-customer-churn-pipeline.svg)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
I noticed that the Docs Badge at the top of the README was pointing to a ReadTheDocs page for an alternative project.

I removed the badge because it appears the the Docs for this project is hosted on Github.io which does not support docs build badges.

---------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
