### PR TITLE
Lock xboost to 1.3.3 in evaluation

### DIFF
--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -15,7 +15,7 @@ def install(package):
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
 
-install("xgboost")
+install("xgboost==1.3.3")
 install("smdebug==1.0.5")
 install("shap==0.39.0")
 install("matplotlib")


### PR DESCRIPTION
*Issue #, if available:*
n/a 

*Description of changes:*
This PR locks the version of xboost in the evaluation script (Model Explainability Step).  This ensures the same version is used for unpickling the model as was used to train/generate it. Without this change, the step can fail as some more recent versions of xboost are unable to load models generated with older versions.  